### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/item_displays_controller.rb
+++ b/app/controllers/item_displays_controller.rb
@@ -4,6 +4,10 @@ class ItemDisplaysController < ApplicationController
   def index
     @item_displays = ItemDisplay.order(id: :DESC)
   end
+
+  def show
+    @item_display = ItemDisplay.find(params[:id])
+  end
  
   def new
     @item_display = ItemDisplay.new

--- a/app/views/item_displays/index.html.erb
+++ b/app/views/item_displays/index.html.erb
@@ -125,11 +125,10 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
       <% if @item_displays.present? %>
       <li class='list'>
        <% @item_displays.each do |item_display| %>
-        <%= link_to '#' do %>
+        <%= link_to item_display_path(item_display.id) do %>
          <%= image_tag item_display.image, class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -147,7 +146,6 @@
         <% end %>
       </li>
       <% else %>
- 
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/item_displays/show.html.erb
+++ b/app/views/item_displays/show.html.erb
@@ -1,13 +1,13 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
+
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item_display.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item_display.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +16,53 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       <%= "#{@item_display.item_price}円" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item_display.ship_burden.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    
+    
+    <% if user_signed_in? && current_user.id == @item_display.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% elsif  user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
+    
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item_display.item_explain %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item_display.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item_display.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item_display.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item_display.ship_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item_display.ship_source.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item_display.ship_date.name %></td>
         </tr>
       </tbody>
     </table>
@@ -78,7 +77,7 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
+  
 
   <div class="comment-box">
     <form>
@@ -102,9 +101,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
+  <a href="#" class="another-item"><%= @item_display.category.name %>をもっと見る</a>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "item_displays#index"
 
-  resources :item_displays, only: [:index, :new, :create ]
+  resources :item_displays, only: [:index, :new, :create, :show ]
   
 end


### PR DESCRIPTION
#what
商品詳細ページを実装した

#why
商品の詳細を確認できるページを表示するため

- ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/145fab10acfd69bd7bbb3ce8fbdf6211
- ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/9f89a7ea831e04d01b4b9583be0ea671
- ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
https://gyazo.com/a647a3080fed9521722dbac340ebd437

下記の項目は商品購入機能が未実装名ため動画はない
- ログイン状態の出品者が、自身の出品した売却済み商品の詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
- ログイン状態の出品者以外のユーザーが、他者の出品した売却済み商品の詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）